### PR TITLE
[PG-3] Add Codacy badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 <p align="center">
+ 
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/9b97ab4399c84bff898001e907e2caf4)](https://app.codacy.com/gh/namely/CoreStore/dashboard)
+[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/9b97ab4399c84bff898001e907e2caf4)](https://app.codacy.com/gh/namely/CoreStore/dashboard)
 <img alt="CoreStore" src="https://github.com/JohnEstropia/CoreStore/raw/develop/CoreStore.png" width=614 />
 <br />
 <br />

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 Unleashing the real power of Core Data with the elegance and safety of Swift
 <br />
 <br />
-<a href="https://app.codacy.com/gh/namely/CoreStore/dashboard"><img alt="Codacy Badge" href="https://app.codacy.com/project/badge/Grade/9b97ab4399c84bff898001e907e2caf4"></a>
-<a href="https://app.codacy.com/gh/namely/CoreStore/dashboard"><img alt="Codacy Badge" href="https://app.codacy.com/project/badge/Coverage/9b97ab4399c84bff898001e907e2caf4"></a>
+<a href="https://app.codacy.com/gh/namely/CoreStore/dashboard"><img alt="Codacy Badge" src="https://app.codacy.com/project/badge/Grade/9b97ab4399c84bff898001e907e2caf4"></a>
+<a href="https://app.codacy.com/gh/namely/CoreStore/dashboard"><img alt="Codacy Badge" src="https://app.codacy.com/project/badge/Coverage/9b97ab4399c84bff898001e907e2caf4"></a>
 <a href="https://app.bitrise.io/app/e736852157296019#/builds"><img alt="Build Status" src="https://img.shields.io/bitrise/e736852157296019/master.svg?label=build&token=vhgAmaiF3tWZoQyFLkKM7g&logo=bitrise" /></a>
 <a href="https://github.com/JohnEstropia/CoreStore/commits"><img alt="Last Commit" src="https://img.shields.io/github/last-commit/johnestropia/corestore.svg?style=flat" /></a>
 <a href="http://cocoadocs.org/docsets/CoreStore"><img alt="Platform" src="https://img.shields.io/cocoapods/p/CoreStore.svg?style=flat" /></a>

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 <p align="center">
- 
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/9b97ab4399c84bff898001e907e2caf4)](https://app.codacy.com/gh/namely/CoreStore/dashboard)
-[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/9b97ab4399c84bff898001e907e2caf4)](https://app.codacy.com/gh/namely/CoreStore/dashboard)
 <img alt="CoreStore" src="https://github.com/JohnEstropia/CoreStore/raw/develop/CoreStore.png" width=614 />
 <br />
 <br />
 Unleashing the real power of Core Data with the elegance and safety of Swift
 <br />
 <br />
+<a href="https://app.codacy.com/gh/namely/CoreStore/dashboard"><img alt="Codacy Badge" href="https://app.codacy.com/project/badge/Grade/9b97ab4399c84bff898001e907e2caf4"></a>
+<a href="https://app.codacy.com/gh/namely/CoreStore/dashboard"><img alt="Codacy Badge" href="https://app.codacy.com/project/badge/Coverage/9b97ab4399c84bff898001e907e2caf4"></a>
 <a href="https://app.bitrise.io/app/e736852157296019#/builds"><img alt="Build Status" src="https://img.shields.io/bitrise/e736852157296019/master.svg?label=build&token=vhgAmaiF3tWZoQyFLkKM7g&logo=bitrise" /></a>
 <a href="https://github.com/JohnEstropia/CoreStore/commits"><img alt="Last Commit" src="https://img.shields.io/github/last-commit/johnestropia/corestore.svg?style=flat" /></a>
 <a href="http://cocoadocs.org/docsets/CoreStore"><img alt="Platform" src="https://img.shields.io/cocoapods/p/CoreStore.svg?style=flat" /></a>


### PR DESCRIPTION

# What does this do?

This PR adds the Codacy badges to the README.md

# Why are we doing this?

The Codacy badges provide an easy at-a-glance view of the code quality and coverage for the repository and increase awareness of quality goals.

Please drop in on the #codacy-discussion channel in Slack if you have any questions.